### PR TITLE
修复未能成功绑定IPv6

### DIFF
--- a/phira-mp-server/src/main.rs
+++ b/phira-mp-server/src/main.rs
@@ -16,7 +16,7 @@ use std::{
         hash_map::{Entry, VacantEntry},
         HashMap,
     },
-    net::{Ipv4Addr, Ipv6Addr, SocketAddr},
+    net::{Ipv6Addr, SocketAddr},
     path::Path,
 };
 use tokio::{net::TcpListener, sync::RwLock};
@@ -101,7 +101,6 @@ async fn main() -> Result<()> {
     let args = Args::parse();
     let port = args.port;
     let addrs: &[SocketAddr] = &[
-        SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), port),
         SocketAddr::new(Ipv6Addr::UNSPECIFIED.into(), port),
     ];
 


### PR DESCRIPTION
详见[issue15](https://github.com/TeamFlos/phira-mp/issues/15)。