### PR TITLE
修复当玩家在房间WaitForReady状态下触发断线重连后点击准备按钮时客户端panic

### DIFF
--- a/phira-mp-server/src/room.rs
+++ b/phira-mp-server/src/room.rs
@@ -88,10 +88,14 @@ impl Room {
             .to_client(self.chart.read().await.as_ref().map(|it| it.id))
     }
 
+    pub async fn fake_room_state(&self) -> RoomState {
+        RoomState::SelectChart(self.chart.read().await.as_ref().map(|it| it.id))
+    }
+
     pub async fn client_state(&self, user: &User) -> ClientRoomState {
         ClientRoomState {
             id: self.id.clone(),
-            state: self.client_room_state().await,
+            state: self.fake_room_state().await,
             live: self.is_live(),
             locked: self.is_locked(),
             cycle: self.is_cycle(),


### PR DESCRIPTION
当客户端在房间状态SelectChart之外触发重连时，由于谱面信息只会跟随SelectChart发送，导致服务器返回的房间信息里没有谱面信息，致使玩家在WaitForReady阶段重连后点击准备按钮时客户端会panic

为确保兼容性，做了一个非常hacky的修改：在重连时发送的房间信息将永远为SelectChart状态，随即发送ChangeState Command以切换到其他状态，这在客户端理应是几乎无感的，且只影响重连