### PR TITLE
fix: silent fallback to default on any server_config.yml error

### DIFF
--- a/phira-mp-server/src/main.rs
+++ b/phira-mp-server/src/main.rs
@@ -107,7 +107,7 @@ async fn main() -> Result<()> {
         println!("Local Address: {}", addr);
     }
 
-    let listener: Server = TcpListener::bind(addrs).await?.into();
+    let listener: Server = TcpListener::bind(addrs).await?.try_into()?;
 
     loop {
         if let Err(err) = listener.accept().await {

--- a/phira-mp-server/src/server.rs
+++ b/phira-mp-server/src/server.rs
@@ -74,6 +74,7 @@ impl TryFrom<TcpListener> for Server {
             }
             Err(e) => Err(e).with_context(|| format!("Failed to open {CONFIG_PATH}")),
         }?;
+        info!("User IDs allowed to monitor matches: {:?}", config.monitors);
         let state = Arc::new(ServerState {
             config,
             sessions: IdMap::default(),

--- a/phira-mp-server/src/server.rs
+++ b/phira-mp-server/src/server.rs
@@ -1,11 +1,13 @@
 use crate::{IdMap, Room, SafeMap, Session, User, vacant_entry};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use phira_mp_common::RoomId;
-use serde::Deserialize;
-use std::{fs::File, sync::Arc};
+use serde::{Deserialize, Serialize};
+use std::{fs::File, io, sync::Arc};
 use tokio::{net::TcpListener, sync::mpsc, task::JoinHandle};
 use tracing::{info, warn};
 use uuid::Uuid;
+
+const CONFIG_PATH: &str = "server_config.yml";
 
 #[derive(Debug, Deserialize)]
 pub struct Chart {
@@ -13,7 +15,7 @@ pub struct Chart {
     pub name: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct ServerConfig {
     pub monitors: Vec<i32>,
 }
@@ -55,13 +57,23 @@ pub struct Server {
     lost_con_handle: JoinHandle<()>,
 }
 
-impl From<TcpListener> for Server {
-    fn from(listener: TcpListener) -> Self {
+impl TryFrom<TcpListener> for Server {
+    type Error = anyhow::Error;
+    fn try_from(listener: TcpListener) -> Result<Server, Self::Error> {
         let (lost_con_tx, mut lost_con_rx) = mpsc::channel(16);
-        let config: ServerConfig = File::open("server_config.yml")
-            .ok()
-            .and_then(|f| serde_yaml::from_reader(f).ok())
-            .unwrap_or_default();
+        let config: ServerConfig = match File::open(CONFIG_PATH) {
+            Ok(file) => serde_yaml::from_reader(file)
+                .with_context(|| format!("Failed to parse {CONFIG_PATH}")),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                let default_cfg = ServerConfig::default();
+                warn!(
+                    "{CONFIG_PATH} is not found.\nFallback to default config:\n```yaml\n{}```",
+                    serde_yaml::to_string(&default_cfg).unwrap()
+                );
+                Ok(default_cfg)
+            }
+            Err(e) => Err(e).with_context(|| format!("Failed to open {CONFIG_PATH}")),
+        }?;
         let state = Arc::new(ServerState {
             config,
             sessions: IdMap::default(),
@@ -91,12 +103,12 @@ impl From<TcpListener> for Server {
             }
         });
 
-        Self {
+        Ok(Self {
             listener,
             state,
 
             lost_con_handle,
-        }
+        })
     }
 }
 


### PR DESCRIPTION
### Changes
- Use default if server_config.yml is not found
  with `warn` log and yaml form of default (as example for users)
  <pre><code>2026-03-27T16:01:57.614117Z  WARN phira_mp_server::server: server_config.yml is not found.
  Fallback to default config:
  ```yaml
  monitors:
  - 2
  ```
  2026-03-28T03:37:50.922670Z  INFO phira_mp_server::server: User IDs allowed to monitor matches: [2]</code></pre>
- Terminate if raised other `io::Error` or `serde_yaml::Error`
  ```
  Error: Failed to parse server_config.yml
  
  Caused by:
      Is a directory (os error 21)
  ```
  ```
  Error: Failed to parse server_config.yml

  Caused by:
      missing field `monitors`
  ```
  ```
  Error: Failed to parse server_config.yml

  Caused by:
      monitors[0]: invalid type: string "41321", expected i32 at line 1 column 12
  ```
- Log current monitors config
  ```
   2026-03-28T03:37:41.402080Z  INFO phira_mp_server::server: User IDs allowed to monitor matches: [41321]
   ```
- `TcpListener` -> `Server` is now `TryFrom`
- Extract `"server_config.yml"` to a const string

chore: log config.monitors with info!

### Past Problem
```rs
let config: ServerConfig = File::open("server_config.yml")  // Result<ServerConfig, io::Error>
    .ok()
    .and_then(|f| serde_yaml::from_reader(f).ok())  // 
    .unwrap_or_default();  // Suppress all error.
// User don't know if it's okay or failed
```
It's now no longer suppress errors, and users can be aware of their current configuration. (just like phira-monitor)
Mivik can still use without `server_config.yml` file in `phira-mp-server::server::CONFIG_PATH`.
But other error is now considered as hard error.

### Extra Consideration (NOT in this PR)

In my environment, the default max log level is `error`.
This patch could be considered to "RUST_LOG=warn by default", and still check `RUST_LOG` first.
This is better than simply writing `RUST_LOG=info` in the `README.md`.
*(Edge Case: If someone set `RUST_LOG` as invalid string, it still apply and suppress, and won't use `warn` by default.)*


```diff
diff --git a/phira-mp-server/src/main.rs b/phira-mp-server/src/main.rs
index d50916f..80bec15 100644
--- a/phira-mp-server/src/main.rs
+++ b/phira-mp-server/src/main.rs
@@ -65,9 +65,11 @@ pub fn init_log(file: &str) -> Result<WorkerGuard> {
                 .with_filter(LevelFilter::DEBUG),
         )
         .with(
-            fmt::layer()
-                .with_writer(std::io::stdout)
-                .with_filter(EnvFilter::from_default_env()),
+            fmt::layer().with_writer(std::io::stdout).with_filter(
+                EnvFilter::builder()
+                    .with_default_directive(LevelFilter::WARN.into())
+                    .from_env_lossy(),
+            ),
         )
         .with(
             filter::Targets::new()
```
